### PR TITLE
Change beats init procedure to not use root

### DIFF
--- a/tests/tevmc/conftest.py
+++ b/tests/tevmc/conftest.py
@@ -43,7 +43,6 @@ def bootstrap_test_stack(tmp_path_factory, config, **kwargs):
         with TEVMController(
             config,
             root_pwd=tmp_path,
-            full=False,
             **kwargs
         ) as _tevmc:
             yield _tevmc

--- a/tevmc/cmdline/build.py
+++ b/tevmc/cmdline/build.py
@@ -298,8 +298,7 @@ def perform_config_build(target_dir, config):
     beats_conf = config['beats'] 
     beats_dir = docker_dir / beats_conf['docker_path']
     beats_conf_dir = beats_dir / beats_conf['conf_dir']
-    os.chown(beats_conf_dir / 'filebeat.yml', uid=0, gid=0)
-    os.chmod(beats_conf_dir / 'filebeat.yml', 0o600)
+    beats_conf = config['beats']
 
 
 def perform_docker_build(target_dir, config, logger):

--- a/tevmc/templates/docker/beats/build/Dockerfile
+++ b/tevmc/templates/docker/beats/build/Dockerfile
@@ -14,5 +14,6 @@ RUN wget https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.15.1-a
     dpkg -i filebeat-7.15.1-amd64.deb
 
 RUN mkdir /root/logs/
+RUN mkdir /root/config
 
-CMD filebeat -e
+CMD ["/bin/bash", "-c", "while true; do sleep 3; done;"]

--- a/tevmc/tevmc.py
+++ b/tevmc/tevmc.py
@@ -634,6 +634,29 @@ class TEVMController:
             exec_id, exec_stream = docker_open_process(
                 self.client,
                 self.containers['beats'],
+                ['chown', '-R', '0:0', '/etc/filebeat/filebeat.yml'])
+
+            ec, out = docker_wait_process(self.client, exec_id, exec_stream)
+            assert ec == 0
+
+            exec_id, exec_stream = docker_open_process(
+                self.client,
+                self.containers['beats'],
+                ['chmod', '600', '/etc/filebeat/filebeat.yml'])
+
+            ec, out = docker_wait_process(self.client, exec_id, exec_stream)
+            assert ec == 0
+
+            exec_id, exec_stream = docker_open_process(
+                self.client,
+                self.containers['beats'],
+                ['filebeat', '-e'])
+
+            time.sleep(3)
+
+            exec_id, exec_stream = docker_open_process(
+                self.client,
+                self.containers['beats'],
                 ['filebeat', 'setup', '--pipelines'])
 
             ec, out = docker_wait_process(self.client, exec_id, exec_stream)


### PR DESCRIPTION
# Fixes #21

## Description

Instead of setting the permissions of the beats config file to root on the build phase we do manual beats startup and config permissions tweaks at runtime, were we have root inside the container.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
