### PR TITLE
Daemon administration API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 asks
+flask
 click
 py-evm
 pytest

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'rlp',
         'web3',
         'asks',
+        'flask',
         'click',
         'pytest',
         'psutil',

--- a/tests/tevmc/patch_test.py
+++ b/tests/tevmc/patch_test.py
@@ -1,0 +1,2 @@
+def tevmc_apply_patch(tevmc):
+    tevmc.logger.info(f'Hello {tevmc.chain_name}!')

--- a/tests/tevmc/test_indexer_reconnect.py
+++ b/tests/tevmc/test_indexer_reconnect.py
@@ -15,13 +15,7 @@ def test_indexer_reconnect(tevmc_local):
         if 'drained' in msg:
             break
 
-    tevmc.cleos.stop_nodeos(
-        from_file=tevmc.config['nodeos']['log_path'])
-    tevmc.is_nodeos_relaunch = True
-
-    time.sleep(4)
-
-    tevmc.start_nodeos()
+    tevmc.restart_nodeos()
 
     for msg in tevmc.stream_logs('telosevm-translator', from_latest=True):
         tevmc.logger.info(msg)

--- a/tevmc/config/default/local.py
+++ b/tevmc/config/default/local.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+daemon = {
+    'port': 12321
+}
+
 redis = {
     'name': 'redis',
     'docker_path': 'redis',
@@ -152,6 +156,8 @@ telos_evm_rpc = {
 }
 
 default_config = {
+    'daemon': daemon,
+
     'redis': redis,
     'elasticsearch': elasticsearch,
     'kibana': kibana,
@@ -160,3 +166,4 @@ default_config = {
     'telosevm-translator': telosevm_translator,
     'telos-evm-rpc': telos_evm_rpc
 }
+

--- a/tevmc/config/default/mainnet.py
+++ b/tevmc/config/default/mainnet.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+daemon = {
+    'port': 12321
+}
+
 redis = {
     'name': 'redis',
     'docker_path': 'redis',
@@ -196,6 +200,8 @@ telos_evm_rpc = {
 }
 
 default_config = {
+    'daemon': daemon,
+
     'redis': redis,
     'elasticsearch': elasticsearch,
     'kibana': kibana,
@@ -204,3 +210,4 @@ default_config = {
     'telosevm-translator': telosevm_translator,
     'telos-evm-rpc': telos_evm_rpc
 }
+

--- a/tevmc/config/default/testnet.py
+++ b/tevmc/config/default/testnet.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+daemon = {
+    'port': 12321
+}
+
 redis = {
     'name': 'redis',
     'docker_path': 'redis',
@@ -193,6 +197,8 @@ telos_evm_rpc = {
 }
 
 default_config = {
+    'daemon': daemon,
+
     'redis': redis,
     'elasticsearch': elasticsearch,
     'kibana': kibana,

--- a/tevmc/routes.py
+++ b/tevmc/routes.py
@@ -1,0 +1,90 @@
+import importlib
+from pathlib import Path
+import time
+
+from flask import request, jsonify
+
+from tevmc.cmdline.build import build_service
+from tevmc.testing.database import ElasticDataIntegrityError, ElasticDriver
+
+
+def add_routes(tevmc: 'TEVMController'):
+
+    app = tevmc.api
+
+    @app.route('/status', methods=['GET'])
+    def status():
+        result = {'services': {}}
+        for cont_name, cont in tevmc.containers.items():
+            cont.reload()
+            result['services'][cont_name] = {
+                'status': cont.status
+            }
+
+        return jsonify(result)
+
+    @app.route('/restart', methods=['POST'])
+    def restart():
+        service = request.json.get('service', None)
+        must_update = request.json.get('update', False)
+        if service is None:
+            tevmc.logger.info('tevmc restart requested, stopping...')
+            tevmc.stop()
+            tevmc.logger.info('tevmc stopped. going up in 3 seconds...')
+            time.sleep(3)
+            tevmc.start()
+
+        elif service == 'nodeos':
+            build_service(
+                Path('.'), 'nodeos', tevmc.config, nocache=must_update)
+            tevmc.restart_nodeos()
+
+        elif service == 'indexer':
+            build_service(
+                Path('.'), 'indexer', tevmc.config, nocache=must_update)
+            tevmc.restart_translator()
+
+        elif service == 'rpc':
+            build_service(
+                Path('.'), 'rpc', tevmc.config, nocache=must_update)
+            tevmc.restart_rpc()
+
+        return jsonify(success=True), 200
+
+
+    @app.route('/patch', methods=['POST'])
+    def patch():
+        pf_path = request.json.get('path', None)
+
+        if not pf_path:
+            return jsonify(error='path parameter is required'), 400
+
+        pf_path = Path(pf_path).resolve()
+
+        if not pf_path.is_file():
+            return jsonify(error='patch file not found'), 400
+
+        spec = importlib.util.spec_from_file_location(
+            'module_name', pf_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        try:
+            patch_fn = getattr(module, 'tevmc_apply_patch')
+            ret = patch_fn(tevmc)
+
+            return jsonify(ret), 200
+
+        except AttributeError:
+            return jsonify(error='patch function not found'), 400
+
+    @app.route('/check', methods=['GET'])
+    def check():
+        try:
+            ElasticDriver(tevmc.config).full_integrity_check()
+            status = 'healthy'
+
+        except ElasticDataIntegrityError as e:
+            status = f'unhealthy: {e}'
+
+        return jsonify({'status': status})

--- a/tevmc/testing/__init__.py
+++ b/tevmc/testing/__init__.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager
 
 from web3 import Web3
 
-from tevmc import TEVMController
 from tevmc.config import (
     build_docker_manifest,
     randomize_conf_ports,
@@ -50,6 +49,7 @@ def get_marker(request, mark_name: str, field: str):
 
 @contextmanager
 def bootstrap_test_stack(request, tmp_path_factory):
+    from tevmc import TEVMController
     config = get_marker(request, 'config', 'kwargs')
     tevmc_params = maybe_get_marker(
         request, 'tevmc_params', 'kwargs', {})


### PR DESCRIPTION
This adds a new administration api to the main `tevmc` daemon.

at `http://localhost:12321`

- `/status` `GET` get statuses of running containers
- `/restart` `POST` takes json param `"service"` and optionally `"update"` to force container rebuild
- `/patch` `POST` takes json param `"path"` applies a python patchfile to the running instance of TEVMC
- `/check` `GET` runs the elasticsearch integrity tests and returns data health status