### PR TITLE
Fix repair on empty DB case, also syntax downgrades

### DIFF
--- a/tevmc/cleos_evm.py
+++ b/tevmc/cleos_evm.py
@@ -351,7 +351,7 @@ class CLEOSEVM(CLEOS):
 
     def eth_get_block_by_number(
         self,
-        block_number: int | str,
+        block_number: Union[int, str],
         full_transactions: bool= False,
         url: Optional[str] = None
     ):

--- a/tevmc/cmdline/repair.py
+++ b/tevmc/cmdline/repair.py
@@ -13,7 +13,7 @@ from docker.types import Mount
 from leap.sugar import download_snapshot
 from tevmc.cmdline.build import perform_docker_build
 from tevmc.config import load_config
-from tevmc.testing.database import ElasticDriver
+from tevmc.testing.database import ElasticDataEmptyError, ElasticDriver
 
 from .cli import cli
 
@@ -93,4 +93,8 @@ def perform_data_repair(config_path, progress=True):
     '--config', default='tevmc.json',
     help='Path to config file.')
 def repair(config):
-    perform_data_repair(Path(config))
+    try:
+        perform_data_repair(Path(config))
+
+    except ElasticDataEmptyError:
+        logging.info('no data to repair')


### PR DESCRIPTION
Syntax downgrade means using old type hinting standards in some functions to be 3.8 compatible