### PR TITLE
Services default must be string

### DIFF
--- a/tevmc/cmdline/up.py
+++ b/tevmc/cmdline/up.py
@@ -22,14 +22,14 @@ from .cli import cli, get_docker_client
     help='Path to lock file for daemon')
 @click.option(
     '--services',
-    default=[
+    default=json.dumps([
         'redis',
         'elastic',
         'kibana',
         'nodeos',
         'indexer',
         'rpc',
-    ],
+    ]),
     help='Services to launch')
 @click.option(
     '--wait/--no-wait', default=False,


### PR DESCRIPTION
Minor bug where the default value for cli entry point for `tevmc up` must be a list encoded as string and is just a list atm